### PR TITLE
IE11 fix

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -34,7 +34,11 @@ document.getElementById("input").oninput = function() {
     });
   }
   document.getElementById("abbrevs").innerHTML = abbrevs;
-}
+};
+
+String.prototype.includes = function (str) {
+  return this.indexOf(str) !== -1;
+};
 
 function scrubText(text) {
   let scrubbedText = "";
@@ -50,47 +54,46 @@ function scrubText(text) {
 }
 
 function findPossibleNumbers(words) {
-  let possibleNumbers = [];
+  let possibleNumbers = {};
   words.forEach(function(word) {
     for (let i = 0; i < word.length; i++) {
       if (numerics.includes(word.charAt(i))) {
-        possibleNumbers.push(word);
+        possibleNumbers[word] = true;
         break;
       }
     }
   });
-  return [...new Set(possibleNumbers)].sort();
+  return Object.keys(possibleNumbers).sort();
 }
 
 function findPossibleAcronyms(words) {
-  let possibleAcronyms = [];
+  let possibleAcronyms = {};
   words.forEach(function(word) {
     if (word.length > 1) {
       if (word == word.toUpperCase() && findPossibleNumbers([word]).length == 0) {
-        possibleAcronyms.push(word);
+        possibleAcronyms[word] = true;
       }
     }
   });
-  return [...new Set(possibleAcronyms)].sort();
+  return Object.keys(possibleAcronyms).sort();
 }
 
 function findPossibleAbbreviations(words) {
-  let possibleAbbreviations = [];
+  let possibleAbbreviations = {};
   words.forEach(function(word_a) {
     let expr = word_a.toLowerCase()
       .split("")
-      .filter(char => lowers.includes(char));
+      .filter(function(c) { return lowers.includes(c); });
     if (expr.length > 1) {
       expr = expr.join(".*") + ".*";
       words.forEach(function(word_b) {
         if (word_a != word_b && word_a.charAt(0) == word_b.charAt(0)) {
-          //console.log("word_a:%s word_b:%s expr:%s", word_a, word_b, expr);
           if (word_b.search(expr) != -1) {
-            possibleAbbreviations.push(word_a + " -> " + word_b);
+            possibleAbbreviations[word_a + " -> " + word_b] = true;
           }
         }
       });
     }
   });
-  return [...new Set(possibleAbbreviations)].sort();
+  return Object.keys(possibleAbbreviations).sort();
 }

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <html>
 
   <head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <html>
 
   <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <link rel="stylesheet" type="text/css" href="style.css">
   </head>
 


### PR DESCRIPTION
Some of the ES6 features that were being used in the original implementation had to be rolled back to earlier forms and/or swapped out for alternative functions, due to IE11's lack of support for ES6 and the fact that the expected user base for this tool will be using some form of IE.

Additionally, miscellaneous HTML errors/warnings have been resolved.

Things that had to be removed or implemented manually include:
- the spread operator (...)
- String.prototype.includes()
- the => operator

Things have currently been tested against the following browsers:
- Firefox 64
- Internet Explorer 11