### PR TITLE
Allow for 1-char words in abbreviation conflicts

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -69,7 +69,7 @@ function findPossibleNumbers(words) {
 function findPossibleAcronyms(words) {
   let possibleAcronyms = {};
   words.forEach(function(word) {
-    if (word.length > 1) {
+    if (word.length > 0) {
       if (word == word.toUpperCase() && findPossibleNumbers([word]).length == 0) {
         possibleAcronyms[word] = true;
       }


### PR DESCRIPTION
This change expands the abbreviation conflict list to include single-character abbreviations for words.

In particular, this will cause cases where "f/" is substituted for "for", and "w/" is substituted for "with".  I have some reservations about how this change may cause the abbreviation conflict list to grow excessively, but I'd rather there be more false positives versus non-reporting of conflicts at this point in development.

Resolves: #1 