### PR TITLE
Add dictionary status message

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -5,6 +5,9 @@ var others = "#$%+.'’ &";
 var allowedChars = uppers + lowers + numerics + others;
 
 function getDictionary(path) {
+  let successMessage = "Dictionary loaded successfully.";
+  let errorMessage = "An error occurred while attempting to load the dictionary.  Certain checker capabilities may be degraded.";
+  document.getElementById("dictionary-status").innerHTML = "Loading dictionary...";
   let words = new Set();
   let rawFile = new XMLHttpRequest();
   rawFile.open("GET", path);
@@ -16,13 +19,19 @@ function getDictionary(path) {
         allText.split("\n").forEach(function (word) {
           words.add(word);
         });
+		if (words.size > 1) {
+		  document.getElementById("dictionary-status").innerHTML = successMessage;
+		} else {
+		  document.getElementById("dictionary-status").innerHTML = errorMessage;
+		}
       }
     }
   };
   try {
     rawFile.send();
   } catch (e) {
-    console.log("An error occurred while attempting to load the dictionary.  Certain checker capabilities may be degraded.");
+    
+    console.log(errorMessage);
     console.log(e);
   }
   return words;
@@ -66,8 +75,10 @@ document.getElementById("input").oninput = function () {
       let word_b = possibleAbbreviations[abbreviation];
       let word_a = abbreviation.replace(word_b, "");
       let line = word_a + " -> " + word_b + "</br>";
-      if (!dictionary.has(word_a) || !dictionary.has(word_b)) {
-        line = "<b>" + line + "</b>";
+	  if (dictionary.size > 1) {
+        if (!dictionary.has(word_a) || !dictionary.has(word_b)) {
+          line = "<b>" + line + "</b>";
+		}
       }
       output += line;
     });

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <div id="word-counts" class="tabcontent"></div>
         <div id="acronyms" class="tabcontent"></div>
         <div id="numbers" class="tabcontent"></div>
+        <div id="dictionary-status"></div>
       </div>
       <div class="footer">
         <p>Please report any issues/bugs here: <a href="https://github.com/crossedxd/epr-checker/issues">GitHub</a></p>

--- a/style.css
+++ b/style.css
@@ -46,6 +46,12 @@
   text-align: center;
 }
 
+#dictionary-status {
+  color: gray;
+  text-align: left;
+  font-style: italic;
+}
+
 .footer {
   -ms-grid-column: 1;
   -ms-grid-column-span: 3;


### PR DESCRIPTION
Adds a status message indicating whether the dictionary load was successful

This change is meant as a QoL change for people with slow connections, and for cases where enable1.txt isn't loaded correctly/successfully.  An initial "loading" message is provided, indicating to the user that something is still going on in the background.  Following the dictionary load, the message is then updated to indicate success/failure.

Resolves: #15 