### PR TITLE
Fixed abbreviation bug

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -73,7 +73,7 @@ document.getElementById("input").oninput = function () {
   if (Object.keys(possibleAbbreviations).length > 0) {
     Object.keys(possibleAbbreviations).sort().forEach(function (abbreviation) {
       let word_b = possibleAbbreviations[abbreviation];
-      let word_a = abbreviation.replace(word_b, "");
+      let word_a = abbreviation.substring(0, abbreviation.length - word_b.length);
       let line = word_a + " -> " + word_b + "</br>";
 	  if (dictionary.size > 1) {
         if (!dictionary.has(word_a) || !dictionary.has(word_b)) {


### PR DESCRIPTION
A fix for the ABBB -> ABBBCCCCCA abbreviation bug

The current logic/storage technique for the abbreviation conflict detection is working correctly, but there was a bug with how the results were being displayed.  The output from findPossibleAbbreviations() was being stored like { word_aword_b: "word_b" }, using the dual-word key to avoid duplicate entries in the output.  The error lay in how the keys were then being split: word_b was originally just bring replace()'d in the key, but this was causing inexplicable behavior.

The fix being employed simply extracts word_a from the key as a substring based on the lengths of the two, which should be a little more stable until I decide to re-implement the abbreviation logic.

Resolves: #23 