### PR TITLE
Acronym definitions

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -24,7 +24,6 @@ function generateRemarks() {
 }
 
 document.getElementById("input").oninput = function () {
-  console.log("Updating...");
   let input = document.getElementById("input").value;
   let words = scrubText(input).split(" ").filter(function (x) { return x != ""; });
   let output = "";

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -18,7 +18,9 @@ document.getElementById("abbreviation-conflicts").style.display = "block";
 function generateRemarks() {
   let remarks = [];
   Object.keys(acronymDefinitions).sort().forEach(function (acronym) {
-    remarks.push(acronymDefinitions[acronym] + " (" + acronym + ")");
+    if (acronymDefinitions[acronym] != "") {
+      remarks.push(acronymDefinitions[acronym] + " (" + acronym + ")");
+    }
   });
   return remarks.join("; ");
 }

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -12,27 +12,27 @@ function getDictionary(path) {
   document.getElementById("dictionary-status").innerHTML = "Loading dictionary...";
   let words = new Set();
   let rawFile = new XMLHttpRequest();
-  rawFile.open("GET", path);
-  rawFile.responseType = "text";
-  rawFile.onreadystatechange = function () {
-    if (rawFile.readyState === 4) {
-      if (rawFile.status === 200 || rawFile.status === 0 ) {
-        let allText = rawFile.responseText;
-        allText.split("\n").forEach(function (word) {
-          words.add(word);
-        });
-		if (words.size > 1) {
-		  document.getElementById("dictionary-status").innerHTML = successMessage;
-		} else {
-		  document.getElementById("dictionary-status").innerHTML = errorMessage;
-		}
-      }
-    }
-  };
   try {
+    rawFile.open("GET", path);
+    rawFile.responseType = "text";
+    rawFile.onreadystatechange = function () {
+      if (rawFile.readyState === 4) {
+        if (rawFile.status === 200 || rawFile.status === 0 ) {
+          let allText = rawFile.responseText;
+          allText.split("\n").forEach(function (word) {
+            words.add(word);
+          });
+      if (words.size > 1) {
+        document.getElementById("dictionary-status").innerHTML = successMessage;
+      } else {
+        document.getElementById("dictionary-status").innerHTML = errorMessage;
+      }
+        }
+      }
+    };
     rawFile.send();
   } catch (e) {
-    
+    document.getElementById("dictionary-status").innerHTML = errorMessage;
     console.log(errorMessage);
     console.log(e);
   }

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -6,40 +6,6 @@ var allowedChars = uppers + lowers + numerics + others;
 
 var acronymDefinitions = {};
 
-function getDictionary(path) {
-  let successMessage = "Dictionary loaded successfully.";
-  let errorMessage = "An error occurred while attempting to load the dictionary.  Certain checker capabilities may be degraded.";
-  document.getElementById("dictionary-status").innerHTML = "Loading dictionary...";
-  let words = new Set();
-  let rawFile = new XMLHttpRequest();
-  try {
-    rawFile.open("GET", path);
-    rawFile.responseType = "text";
-    rawFile.onreadystatechange = function () {
-      if (rawFile.readyState === 4) {
-        if (rawFile.status === 200 || rawFile.status === 0 ) {
-          let allText = rawFile.responseText;
-          allText.split("\r\n").forEach(function (word) {
-            words.add(word);
-          });
-      if (words.size > 1) {
-        document.getElementById("dictionary-status").innerHTML = successMessage;
-      } else {
-        document.getElementById("dictionary-status").innerHTML = errorMessage;
-      }
-        }
-      }
-    };
-    rawFile.send();
-  } catch (e) {
-    document.getElementById("dictionary-status").innerHTML = errorMessage;
-    console.log(errorMessage);
-    console.log(e);
-  }
-  return words;
-}
-var dictionary = getDictionary("enable1.txt");
-
 HTMLCollection.prototype.forEach = Array.prototype.forEach;
 function openTab(evt, tabName) {
   document.getElementsByClassName("tabcontent").forEach(function (x) { x.style.display = "none"; });
@@ -58,6 +24,7 @@ function generateRemarks() {
 }
 
 document.getElementById("input").oninput = function () {
+  console.log("Updating...");
   let input = document.getElementById("input").value;
   let words = scrubText(input).split(" ").filter(function (x) { return x != ""; });
   let output = "";
@@ -120,6 +87,42 @@ document.getElementById("input").oninput = function () {
   }
   document.getElementById("word-counts").innerHTML = output;
 };
+
+function getDictionary(path) {
+  let successMessage = "Dictionary loaded successfully.";
+  let errorMessage = "An error occurred while attempting to load the dictionary.  Certain checker capabilities may be degraded.";
+  document.getElementById("dictionary-status").innerHTML = "Loading dictionary...";
+  let words = new Set();
+  let rawFile = new XMLHttpRequest();
+  try {
+    rawFile.open("GET", path);
+    rawFile.responseType = "text";
+    rawFile.onreadystatechange = function () {
+      if (rawFile.readyState === 4) {
+        if (rawFile.status === 200 || rawFile.status === 0 ) {
+          let allText = rawFile.responseText;
+          allText.split("\r\n").forEach(function (word) {
+            words.add(word);
+          });
+      if (words.size > 1) {
+        document.getElementById("dictionary-status").innerHTML = successMessage;
+      } else {
+        document.getElementById("dictionary-status").innerHTML = errorMessage;
+      }
+        }
+      }
+    };
+    rawFile.send();
+  } catch (e) {
+    document.getElementById("dictionary-status").innerHTML = errorMessage;
+    console.log(errorMessage);
+    console.log(e);
+  }
+  return words;
+}
+
+var dictionary = getDictionary("enable1.txt");
+document.getElementById("input").oninput();
 
 String.prototype.includes = function (str) {
   return this.indexOf(str) !== -1;

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -50,10 +50,11 @@ function openTab(evt, tabName) {
 document.getElementById("abbreviation-conflicts").style.display = "block";
 
 function generateRemarks() {
-  let remarks = "";
+  let remarks = [];
   Object.keys(acronymDefinitions).sort().forEach(function (acronym) {
-    //TODO: implement this
+    remarks.push(acronymDefinitions[acronym] + " (" + acronym + ")");
   });
+  return remarks.join("; ");
 }
 
 document.getElementById("input").oninput = function () {
@@ -73,15 +74,12 @@ document.getElementById("input").oninput = function () {
   if (possibleAcronyms.length > 0) {
     output += "<table width='100%'>";
     possibleAcronyms.forEach(function (acronym) {
-	  let definition = acronymDefinitions[acronym] ? acronymDefinitions[acronym] : "";
-	  output += "<tr>";
-	  output += "<td>" + acronym + "</td>";
-	  output += "<td><input oninput=acronymDefinitions['" + acronym + "']=this.value value='" + definition + "'></input></td>";
-	  output += "</tr>";
+	    let definition = acronymDefinitions[acronym] ? acronymDefinitions[acronym] : "";
+      output += "<tr><td>" + acronym + "</td><td><input oninput=acronymDefinitions['" +
+                acronym + "']=this.value;document.getElementById('remarks').innerHTML=generateRemarks() value='" + definition + "'></input></td></tr>";
     });
-	output += "</table>";
-	output += "<textarea id=remarks rows=4></textarea>";
-    output += "</br>";
+    output += "</table>Generated remarks below:</br>";
+    output += "<textarea class=input-textarea id=remarks rows=4>" + generateRemarks() + "</textarea></br>";
   }
   document.getElementById("acronyms").innerHTML = output;
   output = "";

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -4,6 +4,8 @@ var numerics = "1234567890";
 var others = "#$%+.'’ &";
 var allowedChars = uppers + lowers + numerics + others;
 
+var acronymDefinitions = {};
+
 function getDictionary(path) {
   let successMessage = "Dictionary loaded successfully.";
   let errorMessage = "An error occurred while attempting to load the dictionary.  Certain checker capabilities may be degraded.";
@@ -47,6 +49,13 @@ function openTab(evt, tabName) {
 }
 document.getElementById("abbreviation-conflicts").style.display = "block";
 
+function generateRemarks() {
+  let remarks = "";
+  Object.keys(acronymDefinitions).sort().forEach(function (acronym) {
+    //TODO: implement this
+  });
+}
+
 document.getElementById("input").oninput = function () {
   let input = document.getElementById("input").value;
   let words = scrubText(input).split(" ").filter(function (x) { return x != ""; });
@@ -62,9 +71,16 @@ document.getElementById("input").oninput = function () {
   output = "";
   let possibleAcronyms = findPossibleAcronyms(words);
   if (possibleAcronyms.length > 0) {
+    output += "<table width='100%'>";
     possibleAcronyms.forEach(function (acronym) {
-      output += acronym + "</br>";
+	  let definition = acronymDefinitions[acronym] ? acronymDefinitions[acronym] : "";
+	  output += "<tr>";
+	  output += "<td>" + acronym + "</td>";
+	  output += "<td><input oninput=acronymDefinitions['" + acronym + "']=this.value value='" + definition + "'></input></td>";
+	  output += "</tr>";
     });
+	output += "</table>";
+	output += "<textarea id=remarks rows=4></textarea>";
     output += "</br>";
   }
   document.getElementById("acronyms").innerHTML = output;

--- a/epr-checker.js
+++ b/epr-checker.js
@@ -19,7 +19,7 @@ function getDictionary(path) {
       if (rawFile.readyState === 4) {
         if (rawFile.status === 200 || rawFile.status === 0 ) {
           let allText = rawFile.responseText;
-          allText.split("\n").forEach(function (word) {
+          allText.split("\r\n").forEach(function (word) {
             words.add(word);
           });
       if (words.size > 1) {

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <div id="dictionary-status"></div>
       </div>
       <div class="footer">
-        <p>Please report any issues/bugs here: <a href="https://github.com/crossedxd/epr-checker/issues">GitHub</a></p>
+        <p>Version 0.2.0 | Please report any issues/bugs here: <a href="https://github.com/crossedxd/epr-checker/issues">GitHub</a></p>
       </div>
     </div>
 	  

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <p>Once you've added bullets to the box, up to four types of information will appear on the right.</p>
         <p><b>Abbreviation conflicts:</b> this is a list of words whose letters can all be found in other words.  Bold pairs include one or more words not normally found in a dictionary, increasing the likelyhood that an abbreviation was used.</p>
         <p><b>Word counts:</b> this is a list of all words and their number of occurrences in the text.</p>
-        <p><b>Acronyms:</b> this is a list of all fully-capitalized words found in the bullets.  This list can be used to more easily determine which acronyms need to be added to the remarks section.</p>
+        <p><b>Acronyms:</b> this is a list of all fully-capitalized words found in the bullets.  Typing a description into an acronym's text box will cause the given acronym and its accompanying description to appear in the generated remarks, found below the acronym list.</p>
         <p><b>Numbers:</b> this is a list of all of numbers found in the bullets.</p>
       </div>
       <div class="output-area">

--- a/index.html
+++ b/index.html
@@ -37,13 +37,13 @@
       <div class="output-area">
         <div class="tab">
           <button class="tablinks active" onclick="openTab(event, 'abbreviation-conflicts')">Abbreviation Conflicts</button>
-          <button class="tablinks" onclick="openTab(event, 'word-counts')">Word Counts</button>
           <button class="tablinks" onclick="openTab(event, 'acronyms')">Acronyms</button>
+          <button class="tablinks" onclick="openTab(event, 'word-counts')">Word Counts</button>
           <button class="tablinks" onclick="openTab(event, 'numbers')">Numbers</button>
         </div>
         <div id="abbreviation-conflicts" class="tabcontent"></div>
-        <div id="word-counts" class="tabcontent"></div>
         <div id="acronyms" class="tabcontent"></div>
+        <div id="word-counts" class="tabcontent"></div>
         <div id="numbers" class="tabcontent"></div>
         <div id="dictionary-status"></div>
       </div>


### PR DESCRIPTION
Initial implementation of the acronym description tracking/remarks generator

This change gives the user the ability to input descriptions for acronyms, and have them automatically assembled into a copy/paste-able "Remarks" blurb.  As acronyms are entered into the main input area, they're sorted into a list in the Acronyms tab, each one accompanied by a text box.  If the user types anything into the text box, the acronym is considered "defined" and is automatically included in the "Remarks" blurb.  If a user then deletes aforementioned definition, the acronym is no longer "defined" and falls off the list.

Acronym descriptions are cached so that the user's input isn't lost whenever the input area text is changed (which triggers a page-wide refresh/recalculation).

Also included in this pull is a formatting refresh trigger following the dictionary load, which makes formatting more consistent for users on slow connections.

Resolves: #13, #26