### PR TITLE
Fixed random acronyms appearing in remarks

### DIFF
--- a/epr-checker.js
+++ b/epr-checker.js
@@ -16,9 +16,13 @@ function openTab(evt, tabName) {
 document.getElementById("abbreviation-conflicts").style.display = "block";
 
 function generateRemarks() {
+  let input = document.getElementById("input").value;
+  let words = scrubText(input).split(" ").filter(function (x) { return x != ""; });
+  let acronyms = findPossibleAcronyms(words);
   let remarks = [];
-  Object.keys(acronymDefinitions).sort().forEach(function (acronym) {
-    if (acronymDefinitions[acronym] != "") {
+  Object.keys(acronyms).sort().forEach(function (key) {
+    let acronym = acronyms[key];
+    if (acronymDefinitions[acronym] && acronymDefinitions[acronym] != "") {
       remarks.push(acronymDefinitions[acronym] + " (" + acronym + ")");
     }
   });

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <div id="dictionary-status"></div>
       </div>
       <div class="footer">
-        <p>Version 0.2.0 | Please report any issues/bugs here: <a href="https://github.com/crossedxd/epr-checker/issues">GitHub</a></p>
+        <p>Version 0.2.1 | Please report any issues/bugs here: <a href="https://github.com/crossedxd/epr-checker/issues">GitHub</a></p>
       </div>
     </div>
 	  


### PR DESCRIPTION
These changes fix the issue where previously used/currently removed acronyms would continue to appear in the Remarks section.